### PR TITLE
Stack management

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ WebAssembly only supports basic number types, `i32`, `i64`, `f32`, and `f64`. We
 - `optional`: `i32` indicator (`0` for `none`, `1` for `some`), followed by value for `some`
 - `response`: `i32` indicator (`0` for `err`, `1` for `ok`) followed by ok value, then err value
 
+### Memory Management
+
+The types indicated above that are represented by a pointer to the stack need to actually be allocated space on the stack, and then the stack needs to be properly managed for each function. A global `$stack-pointer` is defined in the standard library. This value points to the top of the stack. Function locals are allocated on the top of the stack, and in the function postlude, the stack pointer is set back to its initial position.
+
 ### Standard Library
 
 Certain Clarity operations are implemented as functions in [_standard.wat_](src/standard/standard.wat). This text format is then used during the build process to generate _standard.wasm_ which gets loaded into `clar2wasm`. Any operations that are cleaner to implement as a function call instead of directly generating Wasm instructions go into this library. For example, you can find the Clarity-style implementation of arithmetic operations in this library. These need to be written out manually because WebAssembly only supports 64-bit integers. The library implements 128-bit arithmetic, with the overflow checks that Clarity requires.

--- a/examples/concat.clar
+++ b/examples/concat.clar
@@ -1,0 +1,3 @@
+(define-private (foo (a (string-ascii 16)) (b (string-ascii 16)))
+  (concat a b)
+)

--- a/src/ast_visitor.rs
+++ b/src/ast_visitor.rs
@@ -8,6 +8,7 @@ use clarity::vm::representations::{Span, TraitDefinition};
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, TraitIdentifier, Value};
 use clarity::vm::{ClarityName, ClarityVersion, SymbolicExpression, SymbolicExpressionType};
 use std::collections::HashMap;
+use walrus::InstrSeqBuilder;
 
 #[derive(Clone)]
 pub struct TypedVar<'a> {
@@ -25,30 +26,37 @@ lazy_static! {
 }
 
 pub trait ASTVisitor<'a> {
-    fn traverse_expr(&mut self, expr: &'a SymbolicExpression) -> bool {
+    fn traverse_expr<'b>(
+        &mut self,
+        builder: InstrSeqBuilder<'b>,
+        expr: &'a SymbolicExpression,
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         match &expr.expr {
-            AtomValue(value) => self.visit_atom_value(expr, value),
-            Atom(name) => self.visit_atom(expr, name),
-            List(exprs) => self.traverse_list(expr, &exprs),
-            LiteralValue(value) => self.visit_literal_value(expr, value),
-            Field(field) => self.visit_field(expr, field),
-            TraitReference(name, trait_def) => self.visit_trait_reference(expr, name, trait_def),
+            AtomValue(value) => self.visit_atom_value(builder, expr, value),
+            Atom(name) => self.visit_atom(builder, expr, name),
+            List(exprs) => self.traverse_list(builder, expr, &exprs),
+            LiteralValue(value) => self.visit_literal_value(builder, expr, value),
+            Field(field) => self.visit_field(builder, expr, field),
+            TraitReference(name, trait_def) => {
+                self.visit_trait_reference(builder, expr, name, trait_def)
+            }
         }
     }
 
     // AST level traverse/visit methods
 
-    fn traverse_list(
+    fn traverse_list<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         list: &'a [SymbolicExpression],
-    ) -> bool {
-        let mut rv = true;
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         if let Some((function_name, args)) = list.split_first() {
             if let Some(function_name) = function_name.match_atom() {
                 if let Some(define_function) = DefineFunctions::lookup_by_name(function_name) {
-                    rv = match define_function {
+                    builder = match define_function {
                         DefineFunctions::Constant => self.traverse_define_constant(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -72,22 +80,26 @@ pub trait ASTVisitor<'a> {
                                     let body = args.get(1).unwrap_or(&DEFAULT_EXPR);
 
                                     match define_function {
-                                        DefineFunctions::PrivateFunction => {
-                                            self.traverse_define_private(expr, name, params, body)
-                                        }
-                                        DefineFunctions::ReadOnlyFunction => {
-                                            self.traverse_define_read_only(expr, name, params, body)
-                                        }
-                                        DefineFunctions::PublicFunction => {
-                                            self.traverse_define_public(expr, name, params, body)
-                                        }
+                                        DefineFunctions::PrivateFunction => self
+                                            .traverse_define_private(
+                                                builder, expr, name, params, body,
+                                            ),
+                                        DefineFunctions::ReadOnlyFunction => self
+                                            .traverse_define_read_only(
+                                                builder, expr, name, params, body,
+                                            ),
+                                        DefineFunctions::PublicFunction => self
+                                            .traverse_define_public(
+                                                builder, expr, name, params, body,
+                                            ),
                                         _ => unreachable!(),
                                     }
                                 }
-                                _ => false,
+                                _ => Err(builder),
                             }
                         }
                         DefineFunctions::NonFungibleToken => self.traverse_define_nft(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -96,6 +108,7 @@ pub trait ASTVisitor<'a> {
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
                         DefineFunctions::FungibleToken => self.traverse_define_ft(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -104,6 +117,7 @@ pub trait ASTVisitor<'a> {
                             args.get(1),
                         ),
                         DefineFunctions::Map => self.traverse_define_map(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -113,6 +127,7 @@ pub trait ASTVisitor<'a> {
                             args.get(2).unwrap_or(&DEFAULT_EXPR),
                         ),
                         DefineFunctions::PersistedVariable => self.traverse_define_data_var(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -124,6 +139,7 @@ pub trait ASTVisitor<'a> {
                         DefineFunctions::Trait => {
                             let params = if args.len() >= 1 { &args[1..] } else { &[] };
                             self.traverse_define_trait(
+                                builder,
                                 expr,
                                 args.get(0)
                                     .unwrap_or(&DEFAULT_EXPR)
@@ -133,6 +149,7 @@ pub trait ASTVisitor<'a> {
                             )
                         }
                         DefineFunctions::UseTrait => self.traverse_use_trait(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -147,6 +164,7 @@ pub trait ASTVisitor<'a> {
                                 }),
                         ),
                         DefineFunctions::ImplTrait => self.traverse_impl_trait(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -156,31 +174,37 @@ pub trait ASTVisitor<'a> {
                                     name: DEFAULT_NAME.clone(),
                                 }),
                         ),
-                    };
+                    }?;
                 } else if let Some(native_function) = NativeFunctions::lookup_by_name_at_version(
                     function_name,
                     &ClarityVersion::latest(), // FIXME(brice): this should probably be passed in
                 ) {
                     use clarity::vm::functions::NativeFunctions::*;
-                    rv = match native_function {
+                    builder = match native_function {
                         Add | Subtract | Multiply | Divide | Modulo | Power | Sqrti | Log2 => {
-                            self.traverse_arithmetic(expr, native_function, &args)
+                            self.traverse_arithmetic(builder, expr, native_function, &args)
                         }
                         BitwiseXor => self.traverse_binary_bitwise(
+                            builder,
                             expr,
                             native_function,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
                         CmpLess | CmpLeq | CmpGreater | CmpGeq | Equals => {
-                            self.traverse_comparison(expr, native_function, &args)
+                            self.traverse_comparison(builder, expr, native_function, &args)
                         }
-                        And | Or => self.traverse_lazy_logical(expr, native_function, &args),
-                        Not => self.traverse_logical(expr, native_function, &args),
-                        ToInt | ToUInt => {
-                            self.traverse_int_cast(expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
+                        And | Or => {
+                            self.traverse_lazy_logical(builder, expr, native_function, &args)
                         }
+                        Not => self.traverse_logical(builder, expr, native_function, &args),
+                        ToInt | ToUInt => self.traverse_int_cast(
+                            builder,
+                            expr,
+                            args.get(0).unwrap_or(&DEFAULT_EXPR),
+                        ),
                         If => self.traverse_if(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
@@ -190,14 +214,16 @@ pub trait ASTVisitor<'a> {
                             let bindings = match_pairs(args.get(0).unwrap_or(&DEFAULT_EXPR))
                                 .unwrap_or_default();
                             let params = if args.len() >= 1 { &args[1..] } else { &[] };
-                            self.traverse_let(expr, &bindings, params)
+                            self.traverse_let(builder, expr, &bindings, params)
                         }
                         ElementAt | ElementAtAlias => self.traverse_element_at(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
                         IndexOf | IndexOfAlias => self.traverse_index_of(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
@@ -209,7 +235,7 @@ pub trait ASTVisitor<'a> {
                                 .match_atom()
                                 .unwrap_or(&DEFAULT_NAME);
                             let params = if args.len() >= 1 { &args[1..] } else { &[] };
-                            self.traverse_map(expr, name, params)
+                            self.traverse_map(builder, expr, name, params)
                         }
                         Fold => {
                             let name = args
@@ -218,6 +244,7 @@ pub trait ASTVisitor<'a> {
                                 .match_atom()
                                 .unwrap_or(&DEFAULT_NAME);
                             self.traverse_fold(
+                                builder,
                                 expr,
                                 name,
                                 args.get(1).unwrap_or(&DEFAULT_EXPR),
@@ -225,11 +252,13 @@ pub trait ASTVisitor<'a> {
                             )
                         }
                         Append => self.traverse_append(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
                         Concat => self.traverse_concat(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
@@ -237,16 +266,20 @@ pub trait ASTVisitor<'a> {
                         AsMaxLen => {
                             match args.get(1).unwrap_or(&DEFAULT_EXPR).match_literal_value() {
                                 Some(Value::UInt(length)) => self.traverse_as_max_len(
+                                    builder,
                                     expr,
                                     args.get(0).unwrap_or(&DEFAULT_EXPR),
                                     *length,
                                 ),
-                                _ => false,
+                                _ => Err(builder),
                             }
                         }
-                        Len => self.traverse_len(expr, args.get(0).unwrap_or(&DEFAULT_EXPR)),
-                        ListCons => self.traverse_list_cons(expr, &args),
+                        Len => {
+                            self.traverse_len(builder, expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
+                        }
+                        ListCons => self.traverse_list_cons(builder, expr, &args),
                         FetchVar => self.traverse_var_get(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -254,6 +287,7 @@ pub trait ASTVisitor<'a> {
                                 .unwrap_or(&DEFAULT_NAME),
                         ),
                         SetVar => self.traverse_var_set(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -273,7 +307,7 @@ pub trait ASTVisitor<'a> {
                                     tuple_map.insert(None, args.get(1).unwrap_or(&DEFAULT_EXPR));
                                     tuple_map
                                 });
-                            self.traverse_map_get(expr, name, &key)
+                            self.traverse_map_get(builder, expr, name, &key)
                         }
                         SetEntry => {
                             let name = args
@@ -293,7 +327,7 @@ pub trait ASTVisitor<'a> {
                                     tuple_map.insert(None, args.get(2).unwrap_or(&DEFAULT_EXPR));
                                     tuple_map
                                 });
-                            self.traverse_map_set(expr, name, &key, &value)
+                            self.traverse_map_set(builder, expr, name, &key, &value)
                         }
                         InsertEntry => {
                             let name = args
@@ -313,7 +347,7 @@ pub trait ASTVisitor<'a> {
                                     tuple_map.insert(None, args.get(2).unwrap_or(&DEFAULT_EXPR));
                                     tuple_map
                                 });
-                            self.traverse_map_insert(expr, name, &key, &value)
+                            self.traverse_map_insert(builder, expr, name, &key, &value)
                         }
                         DeleteEntry => {
                             let name = args
@@ -327,12 +361,15 @@ pub trait ASTVisitor<'a> {
                                     tuple_map.insert(None, args.get(1).unwrap_or(&DEFAULT_EXPR));
                                     tuple_map
                                 });
-                            self.traverse_map_delete(expr, name, &key)
+                            self.traverse_map_delete(builder, expr, name, &key)
                         }
-                        TupleCons => {
-                            self.traverse_tuple(expr, &match_tuple(expr).unwrap_or_default())
-                        }
+                        TupleCons => self.traverse_tuple(
+                            builder,
+                            expr,
+                            &match_tuple(expr).unwrap_or_default(),
+                        ),
                         TupleGet => self.traverse_get(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -341,29 +378,35 @@ pub trait ASTVisitor<'a> {
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
                         TupleMerge => self.traverse_merge(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
-                        Begin => self.traverse_begin(expr, &args),
+                        Begin => self.traverse_begin(builder, expr, &args),
                         Hash160 | Sha256 | Sha512 | Sha512Trunc256 | Keccak256 => self
                             .traverse_hash(
+                                builder,
                                 expr,
                                 native_function,
                                 args.get(0).unwrap_or(&DEFAULT_EXPR),
                             ),
                         Secp256k1Recover => self.traverse_secp256k1_recover(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
                         Secp256k1Verify => self.traverse_secp256k1_verify(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                             args.get(2).unwrap_or(&DEFAULT_EXPR),
                         ),
-                        Print => self.traverse_print(expr, args.get(0).unwrap_or(&DEFAULT_EXPR)),
+                        Print => {
+                            self.traverse_print(builder, expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
+                        }
                         ContractCall => {
                             let function_name = args
                                 .get(1)
@@ -376,6 +419,7 @@ pub trait ASTVisitor<'a> {
                             )) = args.get(0).unwrap_or(&DEFAULT_EXPR).expr
                             {
                                 self.traverse_static_contract_call(
+                                    builder,
                                     expr,
                                     contract_identifier,
                                     function_name,
@@ -383,6 +427,7 @@ pub trait ASTVisitor<'a> {
                                 )
                             } else {
                                 self.traverse_dynamic_contract_call(
+                                    builder,
                                     expr,
                                     args.get(0).unwrap_or(&DEFAULT_EXPR),
                                     function_name,
@@ -390,21 +435,29 @@ pub trait ASTVisitor<'a> {
                                 )
                             }
                         }
-                        AsContract => {
-                            self.traverse_as_contract(expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
-                        }
-                        ContractOf => {
-                            self.traverse_contract_of(expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
-                        }
-                        PrincipalOf => {
-                            self.traverse_principal_of(expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
-                        }
+                        AsContract => self.traverse_as_contract(
+                            builder,
+                            expr,
+                            args.get(0).unwrap_or(&DEFAULT_EXPR),
+                        ),
+                        ContractOf => self.traverse_contract_of(
+                            builder,
+                            expr,
+                            args.get(0).unwrap_or(&DEFAULT_EXPR),
+                        ),
+                        PrincipalOf => self.traverse_principal_of(
+                            builder,
+                            expr,
+                            args.get(0).unwrap_or(&DEFAULT_EXPR),
+                        ),
                         AtBlock => self.traverse_at_block(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
                         GetBlockInfo => self.traverse_get_block_info(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -412,32 +465,58 @@ pub trait ASTVisitor<'a> {
                                 .unwrap_or(&DEFAULT_NAME),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
-                        ConsError => self.traverse_err(expr, args.get(0).unwrap_or(&DEFAULT_EXPR)),
-                        ConsOkay => self.traverse_ok(expr, args.get(0).unwrap_or(&DEFAULT_EXPR)),
-                        ConsSome => self.traverse_some(expr, args.get(0).unwrap_or(&DEFAULT_EXPR)),
+                        ConsError => {
+                            self.traverse_err(builder, expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
+                        }
+                        ConsOkay => {
+                            self.traverse_ok(builder, expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
+                        }
+                        ConsSome => {
+                            self.traverse_some(builder, expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
+                        }
                         DefaultTo => self.traverse_default_to(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
                         Asserts => self.traverse_asserts(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
                         UnwrapRet => self.traverse_unwrap(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
-                        Unwrap => {
-                            self.traverse_unwrap_panic(expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
+                        Unwrap => self.traverse_unwrap_panic(
+                            builder,
+                            expr,
+                            args.get(0).unwrap_or(&DEFAULT_EXPR),
+                        ),
+                        IsOkay => {
+                            self.traverse_is_ok(builder, expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
                         }
-                        IsOkay => self.traverse_is_ok(expr, args.get(0).unwrap_or(&DEFAULT_EXPR)),
-                        IsNone => self.traverse_is_none(expr, args.get(0).unwrap_or(&DEFAULT_EXPR)),
-                        IsErr => self.traverse_is_err(expr, args.get(0).unwrap_or(&DEFAULT_EXPR)),
-                        IsSome => self.traverse_is_some(expr, args.get(0).unwrap_or(&DEFAULT_EXPR)),
+                        IsNone => self.traverse_is_none(
+                            builder,
+                            expr,
+                            args.get(0).unwrap_or(&DEFAULT_EXPR),
+                        ),
+                        IsErr => self.traverse_is_err(
+                            builder,
+                            expr,
+                            args.get(0).unwrap_or(&DEFAULT_EXPR),
+                        ),
+                        IsSome => self.traverse_is_some(
+                            builder,
+                            expr,
+                            args.get(0).unwrap_or(&DEFAULT_EXPR),
+                        ),
                         Filter => self.traverse_filter(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -446,11 +525,13 @@ pub trait ASTVisitor<'a> {
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
                         UnwrapErrRet => self.traverse_unwrap_err(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
                         UnwrapErr => self.traverse_unwrap_err(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
@@ -458,6 +539,7 @@ pub trait ASTVisitor<'a> {
                         Match => {
                             if args.len() == 4 {
                                 self.traverse_match_option(
+                                    builder,
                                     expr,
                                     args.get(0).unwrap_or(&DEFAULT_EXPR),
                                     args.get(1)
@@ -469,6 +551,7 @@ pub trait ASTVisitor<'a> {
                                 )
                             } else {
                                 self.traverse_match_response(
+                                    builder,
                                     expr,
                                     args.get(0).unwrap_or(&DEFAULT_EXPR),
                                     args.get(1)
@@ -484,22 +567,30 @@ pub trait ASTVisitor<'a> {
                                 )
                             }
                         }
-                        TryRet => self.traverse_try(expr, args.get(0).unwrap_or(&DEFAULT_EXPR)),
+                        TryRet => {
+                            self.traverse_try(builder, expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
+                        }
                         StxBurn => self.traverse_stx_burn(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
                         StxTransfer | StxTransferMemo => self.traverse_stx_transfer(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                             args.get(2).unwrap_or(&DEFAULT_EXPR),
                             args.get(3),
                         ),
-                        GetStxBalance => self
-                            .traverse_stx_get_balance(expr, args.get(0).unwrap_or(&DEFAULT_EXPR)),
+                        GetStxBalance => self.traverse_stx_get_balance(
+                            builder,
+                            expr,
+                            args.get(0).unwrap_or(&DEFAULT_EXPR),
+                        ),
                         BurnToken => self.traverse_ft_burn(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -509,6 +600,7 @@ pub trait ASTVisitor<'a> {
                             args.get(2).unwrap_or(&DEFAULT_EXPR),
                         ),
                         TransferToken => self.traverse_ft_transfer(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -519,6 +611,7 @@ pub trait ASTVisitor<'a> {
                             args.get(3).unwrap_or(&DEFAULT_EXPR),
                         ),
                         GetTokenBalance => self.traverse_ft_get_balance(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -527,6 +620,7 @@ pub trait ASTVisitor<'a> {
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
                         GetTokenSupply => self.traverse_ft_get_supply(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -534,6 +628,7 @@ pub trait ASTVisitor<'a> {
                                 .unwrap_or(&DEFAULT_NAME),
                         ),
                         MintToken => self.traverse_ft_mint(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -543,6 +638,7 @@ pub trait ASTVisitor<'a> {
                             args.get(2).unwrap_or(&DEFAULT_EXPR),
                         ),
                         BurnAsset => self.traverse_nft_burn(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -552,6 +648,7 @@ pub trait ASTVisitor<'a> {
                             args.get(2).unwrap_or(&DEFAULT_EXPR),
                         ),
                         TransferAsset => self.traverse_nft_transfer(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -562,6 +659,7 @@ pub trait ASTVisitor<'a> {
                             args.get(3).unwrap_or(&DEFAULT_EXPR),
                         ),
                         MintAsset => self.traverse_nft_mint(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -571,6 +669,7 @@ pub trait ASTVisitor<'a> {
                             args.get(2).unwrap_or(&DEFAULT_EXPR),
                         ),
                         GetAssetOwner => self.traverse_nft_get_owner(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -578,29 +677,41 @@ pub trait ASTVisitor<'a> {
                                 .unwrap_or(&DEFAULT_NAME),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
-                        BuffToIntLe | BuffToUIntLe | BuffToIntBe | BuffToUIntBe => {
-                            self.traverse_buff_cast(expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
-                        }
-                        IsStandard => {
-                            self.traverse_is_standard(expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
-                        }
+                        BuffToIntLe | BuffToUIntLe | BuffToIntBe | BuffToUIntBe => self
+                            .traverse_buff_cast(
+                                builder,
+                                expr,
+                                args.get(0).unwrap_or(&DEFAULT_EXPR),
+                            ),
+                        IsStandard => self.traverse_is_standard(
+                            builder,
+                            expr,
+                            args.get(0).unwrap_or(&DEFAULT_EXPR),
+                        ),
                         PrincipalDestruct => self.traverse_principal_destruct(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                         ),
                         PrincipalConstruct => self.traverse_principal_construct(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                             args.get(2),
                         ),
-                        StringToInt | StringToUInt => {
-                            self.traverse_string_to_int(expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
-                        }
-                        IntToAscii | IntToUtf8 => {
-                            self.traverse_int_to_string(expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
-                        }
+                        StringToInt | StringToUInt => self.traverse_string_to_int(
+                            builder,
+                            expr,
+                            args.get(0).unwrap_or(&DEFAULT_EXPR),
+                        ),
+                        IntToAscii | IntToUtf8 => self.traverse_int_to_string(
+                            builder,
+                            expr,
+                            args.get(0).unwrap_or(&DEFAULT_EXPR),
+                        ),
                         GetBurnBlockInfo => self.traverse_get_burn_block_info(
+                            builder,
                             expr,
                             args.get(0)
                                 .unwrap_or(&DEFAULT_EXPR)
@@ -608,1921 +719,2170 @@ pub trait ASTVisitor<'a> {
                                 .unwrap_or(&DEFAULT_NAME),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
-                        StxGetAccount => self
-                            .traverse_stx_get_account(expr, args.get(0).unwrap_or(&DEFAULT_EXPR)),
+                        StxGetAccount => self.traverse_stx_get_account(
+                            builder,
+                            expr,
+                            args.get(0).unwrap_or(&DEFAULT_EXPR),
+                        ),
                         Slice => self.traverse_slice(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                             args.get(2).unwrap_or(&DEFAULT_EXPR),
                         ),
-                        ToConsensusBuff => self
-                            .traverse_to_consensus_buff(expr, args.get(0).unwrap_or(&DEFAULT_EXPR)),
+                        ToConsensusBuff => self.traverse_to_consensus_buff(
+                            builder,
+                            expr,
+                            args.get(0).unwrap_or(&DEFAULT_EXPR),
+                        ),
                         FromConsensusBuff => self.traverse_from_consensus_buff(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
                         ReplaceAt => self.traverse_replace_at(
+                            builder,
                             expr,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                             args.get(2).unwrap_or(&DEFAULT_EXPR),
                         ),
                         BitwiseAnd | BitwiseOr | BitwiseNot | BitwiseXor2 => {
-                            self.traverse_bitwise(expr, native_function, &args)
+                            self.traverse_bitwise(builder, expr, native_function, &args)
                         }
                         BitwiseLShift | BitwiseRShift => self.traverse_bit_shift(
+                            builder,
                             expr,
                             native_function,
                             args.get(0).unwrap_or(&DEFAULT_EXPR),
                             args.get(1).unwrap_or(&DEFAULT_EXPR),
                         ),
-                    };
+                    }?;
                 } else {
-                    rv = self.traverse_call_user_defined(expr, function_name, args);
+                    builder =
+                        self.traverse_call_user_defined(builder, expr, function_name, args)?;
                 }
             }
         }
-
-        rv && self.visit_list(expr, list)
+        self.visit_list(builder, expr, list)
     }
 
-    fn visit_list(
+    fn visit_list<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _list: &'a [SymbolicExpression],
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn visit_atom_value(&mut self, _expr: &'a SymbolicExpression, _value: &Value) -> bool {
-        true
-    }
-
-    fn visit_atom(&mut self, _expr: &'a SymbolicExpression, _atom: &'a ClarityName) -> bool {
-        true
-    }
-
-    fn visit_literal_value(&mut self, _expr: &'a SymbolicExpression, _value: &Value) -> bool {
-        true
-    }
-
-    fn visit_field(&mut self, _expr: &'a SymbolicExpression, _field: &TraitIdentifier) -> bool {
-        true
-    }
-
-    fn visit_trait_reference(
+    fn visit_atom_value<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
+        _expr: &'a SymbolicExpression,
+        _value: &Value,
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
+    }
+
+    fn visit_atom<'b>(
+        &mut self,
+        builder: InstrSeqBuilder<'b>,
+        _expr: &'a SymbolicExpression,
+        _atom: &'a ClarityName,
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
+    }
+
+    fn visit_literal_value<'b>(
+        &mut self,
+        builder: InstrSeqBuilder<'b>,
+        _expr: &'a SymbolicExpression,
+        _value: &Value,
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
+    }
+
+    fn visit_field<'b>(
+        &mut self,
+        builder: InstrSeqBuilder<'b>,
+        _expr: &'a SymbolicExpression,
+        _field: &TraitIdentifier,
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
+    }
+
+    fn visit_trait_reference<'b>(
+        &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _trait_def: &TraitDefinition,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
     // Higher level traverse/visit methods
 
-    fn traverse_define_constant(
+    fn traverse_define_constant<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a ClarityName,
         value: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(value) && self.visit_define_constant(expr, name, value)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, value)?;
+        self.visit_define_constant(builder, expr, name, value)
     }
 
-    fn visit_define_constant(
+    fn visit_define_constant<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _value: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_define_private(
+    fn traverse_define_private<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a ClarityName,
         parameters: Option<Vec<TypedVar<'a>>>,
         body: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(body) && self.visit_define_private(expr, name, parameters, body)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, body)?;
+        self.visit_define_private(builder, expr, name, parameters, body)
     }
 
-    fn visit_define_private(
+    fn visit_define_private<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _parameters: Option<Vec<TypedVar<'a>>>,
         _body: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_define_read_only(
+    fn traverse_define_read_only<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a ClarityName,
         parameters: Option<Vec<TypedVar<'a>>>,
         body: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(body) && self.visit_define_read_only(expr, name, parameters, body)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, body)?;
+        self.visit_define_read_only(builder, expr, name, parameters, body)
     }
 
-    fn visit_define_read_only(
+    fn visit_define_read_only<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _parameters: Option<Vec<TypedVar<'a>>>,
         _body: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_define_public(
+    fn traverse_define_public<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a ClarityName,
         parameters: Option<Vec<TypedVar<'a>>>,
         body: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(body) && self.visit_define_public(expr, name, parameters, body)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, body)?;
+        self.visit_define_public(builder, expr, name, parameters, body)
     }
 
-    fn visit_define_public(
+    fn visit_define_public<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _parameters: Option<Vec<TypedVar<'a>>>,
         _body: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_define_nft(
+    fn traverse_define_nft<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a ClarityName,
         nft_type: &'a SymbolicExpression,
-    ) -> bool {
-        self.visit_define_nft(expr, name, nft_type)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        self.visit_define_nft(builder, expr, name, nft_type)
     }
 
-    fn visit_define_nft(
+    fn visit_define_nft<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _nft_type: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_define_ft(
+    fn traverse_define_ft<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a ClarityName,
         supply: Option<&'a SymbolicExpression>,
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         if let Some(supply_expr) = supply {
-            if !self.traverse_expr(supply_expr) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, supply_expr)?;
         }
 
-        self.visit_define_ft(expr, name, supply)
+        self.visit_define_ft(builder, expr, name, supply)
     }
 
-    fn visit_define_ft(
+    fn visit_define_ft<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _supply: Option<&'a SymbolicExpression>,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_define_map(
+    fn traverse_define_map<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a ClarityName,
         key_type: &'a SymbolicExpression,
         value_type: &'a SymbolicExpression,
-    ) -> bool {
-        self.visit_define_map(expr, name, key_type, value_type)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        self.visit_define_map(builder, expr, name, key_type, value_type)
     }
 
-    fn visit_define_map(
+    fn visit_define_map<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _key_type: &'a SymbolicExpression,
         _value_type: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_define_data_var(
+    fn traverse_define_data_var<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a ClarityName,
         data_type: &'a SymbolicExpression,
         initial: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(initial) && self.visit_define_data_var(expr, name, data_type, initial)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, initial)?;
+        self.visit_define_data_var(builder, expr, name, data_type, initial)
     }
 
-    fn visit_define_data_var(
+    fn visit_define_data_var<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _data_type: &'a SymbolicExpression,
         _initial: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_define_trait(
+    fn traverse_define_trait<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a ClarityName,
         functions: &'a [SymbolicExpression],
-    ) -> bool {
-        self.visit_define_trait(expr, name, functions)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        self.visit_define_trait(builder, expr, name, functions)
     }
 
-    fn visit_define_trait(
+    fn visit_define_trait<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _functions: &'a [SymbolicExpression],
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_use_trait(
+    fn traverse_use_trait<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a ClarityName,
         trait_identifier: &TraitIdentifier,
-    ) -> bool {
-        self.visit_use_trait(expr, name, trait_identifier)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        self.visit_use_trait(builder, expr, name, trait_identifier)
     }
 
-    fn visit_use_trait(
+    fn visit_use_trait<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _trait_identifier: &TraitIdentifier,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_impl_trait(
+    fn traverse_impl_trait<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         trait_identifier: &TraitIdentifier,
-    ) -> bool {
-        self.visit_impl_trait(expr, trait_identifier)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        self.visit_impl_trait(builder, expr, trait_identifier)
     }
 
-    fn visit_impl_trait(
+    fn visit_impl_trait<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _trait_identifier: &TraitIdentifier,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_arithmetic(
+    fn traverse_arithmetic<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         func: NativeFunctions,
         operands: &'a [SymbolicExpression],
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         for operand in operands {
-            if !self.traverse_expr(operand) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, operand)?;
         }
-        self.visit_arithmetic(expr, func, operands)
+        self.visit_arithmetic(builder, expr, func, operands)
     }
 
-    fn visit_arithmetic(
+    fn visit_arithmetic<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _func: NativeFunctions,
         _operands: &'a [SymbolicExpression],
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_binary_bitwise(
+    fn traverse_binary_bitwise<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         func: NativeFunctions,
         lhs: &'a SymbolicExpression,
         rhs: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(lhs)
-            && self.traverse_expr(rhs)
-            && self.visit_binary_bitwise(expr, func, lhs, rhs)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        for operand in &[lhs, rhs] {
+            builder = self.traverse_expr(builder, operand)?;
+        }
+        self.visit_binary_bitwise(builder, expr, func, lhs, rhs)
     }
 
-    fn visit_binary_bitwise(
+    fn visit_binary_bitwise<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _func: NativeFunctions,
         _lhs: &'a SymbolicExpression,
         _rhs: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_comparison(
+    fn traverse_comparison<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         func: NativeFunctions,
         operands: &'a [SymbolicExpression],
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         for operand in operands {
-            if !self.traverse_expr(operand) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, operand)?;
         }
-        self.visit_comparison(expr, func, operands)
+        self.visit_comparison(builder, expr, func, operands)
     }
 
-    fn visit_comparison(
+    fn visit_comparison<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _func: NativeFunctions,
         _operands: &'a [SymbolicExpression],
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_lazy_logical(
+    fn traverse_lazy_logical<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         function: NativeFunctions,
         operands: &'a [SymbolicExpression],
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         for operand in operands {
-            if !self.traverse_expr(operand) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, operand)?;
         }
-        self.visit_lazy_logical(expr, function, operands)
+        self.visit_lazy_logical(builder, expr, function, operands)
     }
 
-    fn visit_lazy_logical(
+    fn visit_lazy_logical<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _function: NativeFunctions,
         _operands: &'a [SymbolicExpression],
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_logical(
+    fn traverse_logical<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         function: NativeFunctions,
         operands: &'a [SymbolicExpression],
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         for operand in operands {
-            if !self.traverse_expr(operand) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, operand)?;
         }
-        self.visit_logical(expr, function, operands)
+        self.visit_logical(builder, expr, function, operands)
     }
 
-    fn visit_logical(
+    fn visit_logical<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _function: NativeFunctions,
         _operands: &'a [SymbolicExpression],
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_int_cast(
+    fn traverse_int_cast<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         input: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(input) && self.visit_int_cast(expr, input)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, input)?;
+        self.visit_int_cast(builder, expr, input)
     }
 
-    fn visit_int_cast(
+    fn visit_int_cast<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _input: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_if(
+    fn traverse_if<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         cond: &'a SymbolicExpression,
         then_expr: &'a SymbolicExpression,
         else_expr: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(cond)
-            && self.traverse_expr(then_expr)
-            && self.traverse_expr(else_expr)
-            && self.visit_if(expr, cond, then_expr, else_expr)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        for &expr in &[cond, then_expr, else_expr] {
+            builder = self.traverse_expr(builder, expr)?;
+        }
+        self.visit_if(builder, expr, cond, then_expr, else_expr)
     }
 
-    fn visit_if(
+    fn visit_if<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _cond: &'a SymbolicExpression,
         _then_expr: &'a SymbolicExpression,
         _else_expr: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_var_get(&mut self, expr: &'a SymbolicExpression, name: &'a ClarityName) -> bool {
-        self.visit_var_get(expr, name)
-    }
-
-    fn visit_var_get(&mut self, _expr: &'a SymbolicExpression, _name: &'a ClarityName) -> bool {
-        true
-    }
-
-    fn traverse_var_set(
+    fn traverse_var_get<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
+        expr: &'a SymbolicExpression,
+        name: &'a ClarityName,
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        self.visit_var_get(builder, expr, name)
+    }
+
+    fn visit_var_get<'b>(
+        &mut self,
+        builder: InstrSeqBuilder<'b>,
+        _expr: &'a SymbolicExpression,
+        _name: &'a ClarityName,
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
+    }
+
+    fn traverse_var_set<'b>(
+        &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a ClarityName,
         value: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(value) && self.visit_var_set(expr, name, value)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, value)?;
+        self.visit_var_set(builder, expr, name, value)
     }
 
-    fn visit_var_set(
+    fn visit_var_set<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _value: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_map_get(
+    fn traverse_map_get<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a ClarityName,
         key: &HashMap<Option<&'a ClarityName>, &'a SymbolicExpression>,
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         for (_, val) in key {
-            if !self.traverse_expr(val) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, val)?;
         }
-        self.visit_map_get(expr, name, key)
+        self.visit_map_get(builder, expr, name, key)
     }
 
-    fn visit_map_get(
+    fn visit_map_get<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _key: &HashMap<Option<&'a ClarityName>, &'a SymbolicExpression>,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_map_set(
+    fn traverse_map_set<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a ClarityName,
         key: &HashMap<Option<&'a ClarityName>, &'a SymbolicExpression>,
         value: &HashMap<Option<&'a ClarityName>, &'a SymbolicExpression>,
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         for (_, key_val) in key {
-            if !self.traverse_expr(key_val) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, key_val)?;
         }
         for (_, val_val) in value {
-            if !self.traverse_expr(val_val) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, val_val)?;
         }
-        self.visit_map_set(expr, name, key, value)
+        self.visit_map_set(builder, expr, name, key, value)
     }
 
-    fn visit_map_set(
+    fn visit_map_set<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _key: &HashMap<Option<&'a ClarityName>, &'a SymbolicExpression>,
         _value: &HashMap<Option<&'a ClarityName>, &'a SymbolicExpression>,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_map_insert(
+    fn traverse_map_insert<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a ClarityName,
         key: &HashMap<Option<&'a ClarityName>, &'a SymbolicExpression>,
         value: &HashMap<Option<&'a ClarityName>, &'a SymbolicExpression>,
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         for (_, key_val) in key {
-            if !self.traverse_expr(key_val) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, key_val)?;
         }
         for (_, val_val) in value {
-            if !self.traverse_expr(val_val) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, val_val)?;
         }
-        self.visit_map_insert(expr, name, key, value)
+        self.visit_map_insert(builder, expr, name, key, value)
     }
 
-    fn visit_map_insert(
+    fn visit_map_insert<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _key: &HashMap<Option<&'a ClarityName>, &'a SymbolicExpression>,
         _value: &HashMap<Option<&'a ClarityName>, &'a SymbolicExpression>,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_map_delete(
+    fn traverse_map_delete<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a ClarityName,
         key: &HashMap<Option<&'a ClarityName>, &'a SymbolicExpression>,
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         for (_, val) in key {
-            if !self.traverse_expr(val) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, val)?;
         }
-        self.visit_map_delete(expr, name, key)
+        self.visit_map_delete(builder, expr, name, key)
     }
 
-    fn visit_map_delete(
+    fn visit_map_delete<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _key: &HashMap<Option<&'a ClarityName>, &'a SymbolicExpression>,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_tuple(
+    fn traverse_tuple<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         values: &HashMap<Option<&'a ClarityName>, &'a SymbolicExpression>,
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         for (_, val) in values {
-            if !self.traverse_expr(val) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, val)?;
         }
-        self.visit_tuple(expr, values)
+        self.visit_tuple(builder, expr, values)
     }
 
-    fn visit_tuple(
+    fn visit_tuple<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _values: &HashMap<Option<&'a ClarityName>, &'a SymbolicExpression>,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_get(
+    fn traverse_get<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         key: &'a ClarityName,
         tuple: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(tuple) && self.visit_get(expr, key, tuple)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, tuple)?;
+        self.visit_get(builder, expr, key, tuple)
     }
 
-    fn visit_get(
+    fn visit_get<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _key: &'a ClarityName,
         _tuple: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_merge(
+    fn traverse_merge<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         tuple1: &'a SymbolicExpression,
         tuple2: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(tuple1)
-            && self.traverse_expr(tuple2)
-            && self.visit_merge(expr, tuple1, tuple2)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, tuple1)?;
+        builder = self.traverse_expr(builder, tuple2)?;
+        self.visit_merge(builder, expr, tuple1, tuple2)
     }
 
-    fn visit_merge(
+    fn visit_merge<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _tuple1: &'a SymbolicExpression,
         _tuple2: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_begin(
+    fn traverse_begin<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         statements: &'a [SymbolicExpression],
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         for stmt in statements {
-            if !self.traverse_expr(stmt) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, stmt)?;
         }
-        self.visit_begin(expr, statements)
+        self.visit_begin(builder, expr, statements)
     }
 
-    fn visit_begin(
+    fn visit_begin<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _statements: &'a [SymbolicExpression],
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_hash(
+    fn traverse_hash<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         func: NativeFunctions,
         value: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(value) && self.visit_hash(expr, func, value)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, value)?;
+        self.visit_hash(builder, expr, func, value)
     }
 
-    fn visit_hash(
+    fn visit_hash<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _func: NativeFunctions,
         _value: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_secp256k1_recover(
+    fn traverse_secp256k1_recover<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         hash: &'a SymbolicExpression,
         signature: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(hash)
-            && self.traverse_expr(signature)
-            && self.visit_secp256k1_recover(expr, hash, signature)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, hash)?;
+        builder = self.traverse_expr(builder, signature)?;
+        self.visit_secp256k1_recover(builder, expr, hash, signature)
     }
 
-    fn visit_secp256k1_recover(
+    fn visit_secp256k1_recover<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _hash: &SymbolicExpression,
         _signature: &SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_secp256k1_verify(
+    fn traverse_secp256k1_verify<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         hash: &'a SymbolicExpression,
         signature: &'a SymbolicExpression,
         public_key: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(hash)
-            && self.traverse_expr(signature)
-            && self.visit_secp256k1_verify(expr, hash, signature, public_key)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, hash)?;
+        builder = self.traverse_expr(builder, signature)?;
+        self.visit_secp256k1_verify(builder, expr, hash, signature, public_key)
     }
 
-    fn visit_secp256k1_verify(
+    fn visit_secp256k1_verify<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _hash: &SymbolicExpression,
         _signature: &SymbolicExpression,
         _public_key: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_print(
+    fn traverse_print<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         value: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(value) && self.visit_print(expr, value)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, value)?;
+        self.visit_print(builder, expr, value)
     }
 
-    fn visit_print(
+    fn visit_print<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _value: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_static_contract_call(
+    fn traverse_static_contract_call<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         contract_identifier: &'a QualifiedContractIdentifier,
         function_name: &'a ClarityName,
         args: &'a [SymbolicExpression],
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         for arg in args.iter() {
-            if !self.traverse_expr(arg) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, arg)?;
         }
-        self.visit_static_contract_call(expr, contract_identifier, function_name, args)
+        self.visit_static_contract_call(builder, expr, contract_identifier, function_name, args)
     }
 
-    fn visit_static_contract_call(
+    fn visit_static_contract_call<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _contract_identifier: &'a QualifiedContractIdentifier,
         _function_name: &'a ClarityName,
         _args: &'a [SymbolicExpression],
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_dynamic_contract_call(
+    fn traverse_dynamic_contract_call<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         trait_ref: &'a SymbolicExpression,
         function_name: &'a ClarityName,
         args: &'a [SymbolicExpression],
-    ) -> bool {
-        self.traverse_expr(trait_ref);
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, trait_ref)?;
         for arg in args.iter() {
-            if !self.traverse_expr(arg) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, arg)?;
         }
-        self.visit_dynamic_contract_call(expr, trait_ref, function_name, args)
+        self.visit_dynamic_contract_call(builder, expr, trait_ref, function_name, args)
     }
 
-    fn visit_dynamic_contract_call(
+    fn visit_dynamic_contract_call<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _trait_ref: &'a SymbolicExpression,
         _function_name: &'a ClarityName,
         _args: &'a [SymbolicExpression],
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_as_contract(
+    fn traverse_as_contract<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         inner: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(inner) && self.visit_as_contract(expr, inner)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, inner)?;
+        self.visit_as_contract(builder, expr, inner)
     }
 
-    fn visit_as_contract(
+    fn visit_as_contract<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _inner: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_contract_of(
+    fn traverse_contract_of<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(name) && self.visit_contract_of(expr, name)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, name)?;
+        self.visit_contract_of(builder, expr, name)
     }
 
-    fn visit_contract_of(
+    fn visit_contract_of<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_principal_of(
+    fn traverse_principal_of<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         public_key: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(public_key) && self.visit_principal_of(expr, public_key)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, public_key)?;
+        self.visit_principal_of(builder, expr, public_key)
     }
 
-    fn visit_principal_of(
+    fn visit_principal_of<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _public_key: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_at_block(
+    fn traverse_at_block<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         block: &'a SymbolicExpression,
         inner: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(block)
-            && self.traverse_expr(inner)
-            && self.visit_at_block(expr, block, inner)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, block)?;
+        builder = self.traverse_expr(builder, inner)?;
+        self.visit_at_block(builder, expr, block, inner)
     }
 
-    fn visit_at_block(
+    fn visit_at_block<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _block: &'a SymbolicExpression,
         _inner: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_get_block_info(
+    fn traverse_get_block_info<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         prop_name: &'a ClarityName,
         block: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(block) && self.visit_get_block_info(expr, prop_name, block)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, block)?;
+        self.visit_get_block_info(builder, expr, prop_name, block)
     }
 
-    fn visit_get_block_info(
+    fn visit_get_block_info<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _prop_name: &'a ClarityName,
         _block: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_err(
+    fn traverse_err<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         value: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(value) && self.visit_err(expr, value)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, value)?;
+        self.visit_err(builder, expr, value)
     }
 
-    fn visit_err(&mut self, _expr: &'a SymbolicExpression, _value: &'a SymbolicExpression) -> bool {
-        true
-    }
-
-    fn traverse_ok(&mut self, expr: &'a SymbolicExpression, value: &'a SymbolicExpression) -> bool {
-        self.traverse_expr(value) && self.visit_ok(expr, value)
-    }
-
-    fn visit_ok(&mut self, _expr: &'a SymbolicExpression, _value: &'a SymbolicExpression) -> bool {
-        true
-    }
-
-    fn traverse_some(
+    fn visit_err<'b>(
         &mut self,
-        expr: &'a SymbolicExpression,
-        value: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(value) && self.visit_some(expr, value)
-    }
-
-    fn visit_some(
-        &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _value: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_default_to(
+    fn traverse_ok<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
+        expr: &'a SymbolicExpression,
+        value: &'a SymbolicExpression,
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, value)?;
+        self.visit_ok(builder, expr, value)
+    }
+
+    fn visit_ok<'b>(
+        &mut self,
+        builder: InstrSeqBuilder<'b>,
+        _expr: &'a SymbolicExpression,
+        _value: &'a SymbolicExpression,
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
+    }
+
+    fn traverse_some<'b>(
+        &mut self,
+        mut builder: InstrSeqBuilder<'b>,
+        expr: &'a SymbolicExpression,
+        value: &'a SymbolicExpression,
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, value)?;
+        self.visit_some(builder, expr, value)
+    }
+
+    fn visit_some<'b>(
+        &mut self,
+        builder: InstrSeqBuilder<'b>,
+        _expr: &'a SymbolicExpression,
+        _value: &'a SymbolicExpression,
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
+    }
+
+    fn traverse_default_to<'b>(
+        &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         default: &'a SymbolicExpression,
         value: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(default)
-            && self.traverse_expr(value)
-            && self.visit_default_to(expr, default, value)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, default)?;
+        builder = self.traverse_expr(builder, value)?;
+        self.visit_default_to(builder, expr, default, value)
     }
 
-    fn visit_default_to(
+    fn visit_default_to<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _default: &'a SymbolicExpression,
         _value: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_unwrap(
+    fn traverse_unwrap<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         input: &'a SymbolicExpression,
         throws: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(input)
-            && self.traverse_expr(throws)
-            && self.visit_unwrap(expr, input, throws)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, input)?;
+        builder = self.traverse_expr(builder, throws)?;
+        self.visit_unwrap(builder, expr, input, throws)
     }
 
-    fn visit_unwrap(
+    fn visit_unwrap<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _input: &'a SymbolicExpression,
         _throws: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_unwrap_err(
+    fn traverse_unwrap_err<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         input: &'a SymbolicExpression,
         throws: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(input)
-            && self.traverse_expr(throws)
-            && self.visit_unwrap_err(expr, input, throws)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, input)?;
+        builder = self.traverse_expr(builder, throws)?;
+        self.visit_unwrap_err(builder, expr, input, throws)
     }
 
-    fn visit_unwrap_err(
+    fn visit_unwrap_err<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _input: &'a SymbolicExpression,
         _throws: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_is_ok(
+    fn traverse_is_ok<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         value: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(value) && self.visit_is_ok(expr, value)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, value)?;
+        self.visit_is_ok(builder, expr, value)
     }
 
-    fn visit_is_ok(
+    fn visit_is_ok<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _value: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_is_none(
+    fn traverse_is_none<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         value: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(value) && self.visit_is_none(expr, value)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, value)?;
+        self.visit_is_none(builder, expr, value)
     }
 
-    fn visit_is_none(
+    fn visit_is_none<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _value: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_is_err(
+    fn traverse_is_err<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         value: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(value) && self.visit_is_err(expr, value)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, value)?;
+        self.visit_is_err(builder, expr, value)
     }
 
-    fn visit_is_err(
+    fn visit_is_err<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _value: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_is_some(
+    fn traverse_is_some<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         value: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(value) && self.visit_is_some(expr, value)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, value)?;
+        self.visit_is_some(builder, expr, value)
     }
 
-    fn visit_is_some(
+    fn visit_is_some<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _value: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_filter(
+    fn traverse_filter<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         func: &'a ClarityName,
         sequence: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(sequence) && self.visit_filter(expr, func, sequence)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, sequence)?;
+        self.visit_filter(builder, expr, func, sequence)
     }
 
-    fn visit_filter(
+    fn visit_filter<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _func: &'a ClarityName,
         _sequence: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_unwrap_panic(
+    fn traverse_unwrap_panic<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         input: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(input) && self.visit_unwrap_panic(expr, input)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, input)?;
+        self.visit_unwrap_panic(builder, expr, input)
     }
 
-    fn visit_unwrap_panic(
+    fn visit_unwrap_panic<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _input: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_unwrap_err_panic(
+    fn traverse_unwrap_err_panic<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         input: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(input) && self.visit_unwrap_err_panic(expr, input)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, input)?;
+        self.visit_unwrap_err_panic(builder, expr, input)
     }
 
-    fn visit_unwrap_err_panic(
+    fn visit_unwrap_err_panic<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _input: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_match_option(
+    fn traverse_match_option<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         input: &'a SymbolicExpression,
         some_name: &'a ClarityName,
         some_branch: &'a SymbolicExpression,
         none_branch: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(input)
-            && self.traverse_expr(some_branch)
-            && self.traverse_expr(none_branch)
-            && self.visit_match_option(expr, input, some_name, some_branch, none_branch)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, input)?;
+        builder = self.traverse_expr(builder, some_branch)?;
+        builder = self.traverse_expr(builder, none_branch)?;
+        self.visit_match_option(builder, expr, input, some_name, some_branch, none_branch)
     }
 
-    fn visit_match_option(
+    fn visit_match_option<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _input: &'a SymbolicExpression,
         _some_name: &'a ClarityName,
         _some_branch: &'a SymbolicExpression,
         _none_branch: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_match_response(
+    fn traverse_match_response<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         input: &'a SymbolicExpression,
         ok_name: &'a ClarityName,
         ok_branch: &'a SymbolicExpression,
         err_name: &'a ClarityName,
         err_branch: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(input)
-            && self.traverse_expr(ok_branch)
-            && self.traverse_expr(err_branch)
-            && self.visit_match_response(expr, input, ok_name, ok_branch, err_name, err_branch)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, input)?;
+        builder = self.traverse_expr(builder, ok_branch)?;
+        builder = self.traverse_expr(builder, err_branch)?;
+        self.visit_match_response(
+            builder, expr, input, ok_name, ok_branch, err_name, err_branch,
+        )
     }
 
-    fn visit_match_response(
+    fn visit_match_response<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _input: &'a SymbolicExpression,
         _ok_name: &'a ClarityName,
         _ok_branch: &'a SymbolicExpression,
         _err_name: &'a ClarityName,
         _err_branch: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_try(
+    fn traverse_try<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         input: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(input) && self.visit_try(expr, input)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, input)?;
+        self.visit_try(builder, expr, input)
     }
 
-    fn visit_try(&mut self, _expr: &'a SymbolicExpression, _input: &'a SymbolicExpression) -> bool {
-        true
-    }
-
-    fn traverse_asserts(
+    fn visit_try<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
+        _expr: &'a SymbolicExpression,
+        _input: &'a SymbolicExpression,
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
+    }
+
+    fn traverse_asserts<'b>(
+        &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         cond: &'a SymbolicExpression,
         thrown: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(cond)
-            && self.traverse_expr(thrown)
-            && self.visit_asserts(expr, cond, thrown)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, cond)?;
+        builder = self.traverse_expr(builder, thrown)?;
+        self.visit_asserts(builder, expr, cond, thrown)
     }
 
-    fn visit_asserts(
+    fn visit_asserts<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _cond: &'a SymbolicExpression,
         _thrown: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_stx_burn(
+    fn traverse_stx_burn<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         amount: &'a SymbolicExpression,
         sender: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(amount)
-            && self.traverse_expr(sender)
-            && self.visit_stx_burn(expr, amount, sender)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, amount)?;
+        builder = self.traverse_expr(builder, sender)?;
+        self.visit_stx_burn(builder, expr, amount, sender)
     }
 
-    fn visit_stx_burn(
+    fn visit_stx_burn<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _amount: &'a SymbolicExpression,
         _sender: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_stx_transfer(
+    fn traverse_stx_transfer<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         amount: &'a SymbolicExpression,
         sender: &'a SymbolicExpression,
         recipient: &'a SymbolicExpression,
         memo: Option<&'a SymbolicExpression>,
-    ) -> bool {
-        self.traverse_expr(amount)
-            && self.traverse_expr(sender)
-            && self.traverse_expr(recipient)
-            && (memo.is_none() || self.traverse_expr(memo.unwrap()))
-            && self.visit_stx_transfer(expr, amount, sender, recipient, memo)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, amount)?;
+        builder = self.traverse_expr(builder, sender)?;
+        builder = self.traverse_expr(builder, recipient)?;
+        if let Some(memo) = memo {
+            builder = self.traverse_expr(builder, memo)?;
+        }
+        self.visit_stx_transfer(builder, expr, amount, sender, recipient, memo)
     }
 
-    fn visit_stx_transfer(
+    fn visit_stx_transfer<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _amount: &'a SymbolicExpression,
         _sender: &'a SymbolicExpression,
         _recipient: &'a SymbolicExpression,
         _memo: Option<&'a SymbolicExpression>,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_stx_get_balance(
+    fn traverse_stx_get_balance<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         owner: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(owner) && self.visit_stx_get_balance(expr, owner)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, owner)?;
+        self.visit_stx_get_balance(builder, expr, owner)
     }
 
-    fn visit_stx_get_balance(
+    fn visit_stx_get_balance<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _owner: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_ft_burn(
+    fn traverse_ft_burn<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         token: &'a ClarityName,
         amount: &'a SymbolicExpression,
         sender: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(amount)
-            && self.traverse_expr(sender)
-            && self.visit_ft_burn(expr, token, amount, sender)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, amount)?;
+        builder = self.traverse_expr(builder, sender)?;
+        self.visit_ft_burn(builder, expr, token, amount, sender)
     }
 
-    fn visit_ft_burn(
+    fn visit_ft_burn<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _token: &'a ClarityName,
         _amount: &'a SymbolicExpression,
         _sender: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_ft_transfer(
+    fn traverse_ft_transfer<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         token: &'a ClarityName,
         amount: &'a SymbolicExpression,
         sender: &'a SymbolicExpression,
         recipient: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(amount)
-            && self.traverse_expr(sender)
-            && self.traverse_expr(recipient)
-            && self.visit_ft_transfer(expr, token, amount, sender, recipient)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, amount)?;
+        builder = self.traverse_expr(builder, sender)?;
+        builder = self.traverse_expr(builder, recipient)?;
+        self.visit_ft_transfer(builder, expr, token, amount, sender, recipient)
     }
 
-    fn visit_ft_transfer(
+    fn visit_ft_transfer<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _token: &'a ClarityName,
         _amount: &'a SymbolicExpression,
         _sender: &'a SymbolicExpression,
         _recipient: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_ft_get_balance(
+    fn traverse_ft_get_balance<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         token: &'a ClarityName,
         owner: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(owner) && self.visit_ft_get_balance(expr, token, owner)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, owner)?;
+        self.visit_ft_get_balance(builder, expr, token, owner)
     }
 
-    fn visit_ft_get_balance(
+    fn visit_ft_get_balance<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _token: &'a ClarityName,
         _owner: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_ft_get_supply(
+    fn traverse_ft_get_supply<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         token: &'a ClarityName,
-    ) -> bool {
-        self.visit_ft_get_supply(expr, token)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        self.visit_ft_get_supply(builder, expr, token)
     }
 
-    fn visit_ft_get_supply(
+    fn visit_ft_get_supply<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _token: &'a ClarityName,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_ft_mint(
+    fn traverse_ft_mint<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         token: &'a ClarityName,
         amount: &'a SymbolicExpression,
         recipient: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(amount)
-            && self.traverse_expr(recipient)
-            && self.visit_ft_mint(expr, token, amount, recipient)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, amount)?;
+        builder = self.traverse_expr(builder, recipient)?;
+        self.visit_ft_mint(builder, expr, token, amount, recipient)
     }
 
-    fn visit_ft_mint(
+    fn visit_ft_mint<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _token: &'a ClarityName,
         _amount: &'a SymbolicExpression,
         _recipient: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_nft_burn(
+    fn traverse_nft_burn<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         token: &'a ClarityName,
         identifier: &'a SymbolicExpression,
         sender: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(identifier)
-            && self.traverse_expr(sender)
-            && self.visit_nft_burn(expr, token, identifier, sender)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, identifier)?;
+        builder = self.traverse_expr(builder, sender)?;
+        self.visit_nft_burn(builder, expr, token, identifier, sender)
     }
 
-    fn visit_nft_burn(
+    fn visit_nft_burn<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _token: &'a ClarityName,
         _identifier: &'a SymbolicExpression,
         _sender: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_nft_transfer(
+    fn traverse_nft_transfer<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         token: &'a ClarityName,
         identifier: &'a SymbolicExpression,
         sender: &'a SymbolicExpression,
         recipient: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(identifier)
-            && self.traverse_expr(sender)
-            && self.traverse_expr(recipient)
-            && self.visit_nft_transfer(expr, token, identifier, sender, recipient)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, identifier)?;
+        builder = self.traverse_expr(builder, sender)?;
+        builder = self.traverse_expr(builder, recipient)?;
+        self.visit_nft_transfer(builder, expr, token, identifier, sender, recipient)
     }
 
-    fn visit_nft_transfer(
+    fn visit_nft_transfer<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _token: &'a ClarityName,
         _identifier: &'a SymbolicExpression,
         _sender: &'a SymbolicExpression,
         _recipient: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_nft_mint(
+    fn traverse_nft_mint<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         token: &'a ClarityName,
         identifier: &'a SymbolicExpression,
         recipient: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(identifier)
-            && self.traverse_expr(recipient)
-            && self.visit_nft_mint(expr, token, identifier, recipient)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, identifier)?;
+        builder = self.traverse_expr(builder, recipient)?;
+        self.visit_nft_mint(builder, expr, token, identifier, recipient)
     }
 
-    fn visit_nft_mint(
+    fn visit_nft_mint<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _token: &'a ClarityName,
         _identifier: &'a SymbolicExpression,
         _recipient: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_nft_get_owner(
+    fn traverse_nft_get_owner<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         token: &'a ClarityName,
         identifier: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(identifier) && self.visit_nft_get_owner(expr, token, identifier)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, identifier)?;
+        self.visit_nft_get_owner(builder, expr, token, identifier)
     }
 
-    fn visit_nft_get_owner(
+    fn visit_nft_get_owner<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _token: &'a ClarityName,
         _identifier: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_let(
+    fn traverse_let<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         bindings: &HashMap<&'a ClarityName, &'a SymbolicExpression>,
         body: &'a [SymbolicExpression],
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         for (_, val) in bindings {
-            if !self.traverse_expr(val) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, val)?;
         }
         for expr in body {
-            if !self.traverse_expr(expr) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, expr)?;
         }
-        self.visit_let(expr, bindings, body)
+        self.visit_let(builder, expr, bindings, body)
     }
 
-    fn visit_let(
+    fn visit_let<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _bindings: &HashMap<&'a ClarityName, &'a SymbolicExpression>,
         _body: &'a [SymbolicExpression],
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_map(
+    fn traverse_map<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         func: &'a ClarityName,
         sequences: &'a [SymbolicExpression],
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         for sequence in sequences {
-            if !self.traverse_expr(sequence) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, sequence)?;
         }
-        self.visit_map(expr, func, sequences)
+        self.visit_map(builder, expr, func, sequences)
     }
 
-    fn visit_map(
+    fn visit_map<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _func: &'a ClarityName,
         _sequences: &'a [SymbolicExpression],
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_fold(
+    fn traverse_fold<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         func: &'a ClarityName,
         sequence: &'a SymbolicExpression,
         initial: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(sequence)
-            && self.traverse_expr(initial)
-            && self.visit_fold(expr, func, sequence, initial)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, sequence)?;
+        builder = self.traverse_expr(builder, initial)?;
+        self.visit_fold(builder, expr, func, sequence, initial)
     }
 
-    fn visit_fold(
+    fn visit_fold<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _func: &'a ClarityName,
         _sequence: &'a SymbolicExpression,
         _initial: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_append(
+    fn traverse_append<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         list: &'a SymbolicExpression,
         value: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(list)
-            && self.traverse_expr(value)
-            && self.visit_append(expr, list, value)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, list)?;
+        builder = self.traverse_expr(builder, value)?;
+        self.visit_append(builder, expr, list, value)
     }
 
-    fn visit_append(
+    fn visit_append<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _list: &'a SymbolicExpression,
         _value: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_concat(
+    fn traverse_concat<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         lhs: &'a SymbolicExpression,
         rhs: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(lhs) && self.traverse_expr(rhs) && self.visit_concat(expr, lhs, rhs)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, lhs)?;
+        builder = self.traverse_expr(builder, rhs)?;
+        self.visit_concat(builder, expr, lhs, rhs)
     }
 
-    fn visit_concat(
+    fn visit_concat<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _lhs: &'a SymbolicExpression,
         _rhs: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_as_max_len(
+    fn traverse_as_max_len<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         sequence: &'a SymbolicExpression,
         length: u128,
-    ) -> bool {
-        self.traverse_expr(sequence) && self.visit_as_max_len(expr, sequence, length)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, sequence)?;
+        self.visit_as_max_len(builder, expr, sequence, length)
     }
 
-    fn visit_as_max_len(
+    fn visit_as_max_len<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _sequence: &'a SymbolicExpression,
         _length: u128,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_len(
+    fn traverse_len<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         sequence: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(sequence) && self.visit_len(expr, sequence)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, sequence)?;
+        self.visit_len(builder, expr, sequence)
     }
 
-    fn visit_len(
+    fn visit_len<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _sequence: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_element_at(
+    fn traverse_element_at<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         sequence: &'a SymbolicExpression,
         index: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(sequence)
-            && self.traverse_expr(index)
-            && self.visit_element_at(expr, sequence, index)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, sequence)?;
+        builder = self.traverse_expr(builder, index)?;
+        self.visit_element_at(builder, expr, sequence, index)
     }
 
-    fn visit_element_at(
+    fn visit_element_at<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _sequence: &'a SymbolicExpression,
         _index: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_index_of(
+    fn traverse_index_of<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         sequence: &'a SymbolicExpression,
         item: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(sequence)
-            && self.traverse_expr(item)
-            && self.visit_element_at(expr, sequence, item)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, sequence)?;
+        builder = self.traverse_expr(builder, item)?;
+        self.visit_element_at(builder, expr, sequence, item)
     }
 
-    fn visit_index_of(
+    fn visit_index_of<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _sequence: &'a SymbolicExpression,
         _item: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_list_cons(
+    fn traverse_list_cons<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         args: &'a [SymbolicExpression],
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         for arg in args.iter() {
-            if !self.traverse_expr(arg) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, arg)?;
         }
-        self.visit_list_cons(expr, args)
+        self.visit_list_cons(builder, expr, args)
     }
 
-    fn visit_list_cons(
+    fn visit_list_cons<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _args: &'a [SymbolicExpression],
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_call_user_defined(
+    fn traverse_call_user_defined<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         name: &'a ClarityName,
         args: &'a [SymbolicExpression],
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         for arg in args.iter() {
-            if !self.traverse_expr(arg) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, arg)?;
         }
-        self.visit_call_user_defined(expr, name, args)
+        self.visit_call_user_defined(builder, expr, name, args)
     }
 
-    fn visit_call_user_defined(
+    fn visit_call_user_defined<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _name: &'a ClarityName,
         _args: &'a [SymbolicExpression],
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_buff_cast(
+    fn traverse_buff_cast<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         input: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(input) && self.visit_buff_cast(expr, input)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, input)?;
+        self.visit_buff_cast(builder, expr, input)
     }
 
-    fn visit_buff_cast(
+    fn visit_buff_cast<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _input: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_is_standard(
+    fn traverse_is_standard<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         value: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(value) && self.visit_is_standard(expr, value)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, value)?;
+        self.visit_is_standard(builder, expr, value)
     }
 
-    fn visit_is_standard(
+    fn visit_is_standard<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _value: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_principal_destruct(
+    fn traverse_principal_destruct<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         principal: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(principal) && self.visit_principal_destruct(expr, principal)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, principal)?;
+        self.visit_principal_destruct(builder, expr, principal)
     }
 
-    fn visit_principal_destruct(
+    fn visit_principal_destruct<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _principal: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_principal_construct(
+    fn traverse_principal_construct<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         buff1: &'a SymbolicExpression,
         buff20: &'a SymbolicExpression,
         contract: Option<&'a SymbolicExpression>,
-    ) -> bool {
-        self.traverse_expr(buff1)
-            && self.traverse_expr(buff20)
-            && (contract.is_none() || self.traverse_expr(contract.unwrap()))
-            && self.visit_principal_construct(expr, buff1, buff20, contract)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, buff1)?;
+        builder = self.traverse_expr(builder, buff20)?;
+        if let Some(contract) = contract {
+            builder = self.traverse_expr(builder, contract)?;
+        }
+        self.visit_principal_construct(builder, expr, buff1, buff20, contract)
     }
 
-    fn visit_principal_construct(
+    fn visit_principal_construct<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _buff1: &'a SymbolicExpression,
         _buff20: &'a SymbolicExpression,
         _contract: Option<&'a SymbolicExpression>,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_string_to_int(
+    fn traverse_string_to_int<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         input: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(input) && self.visit_string_to_int(expr, input)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, input)?;
+        self.visit_string_to_int(builder, expr, input)
     }
 
-    fn visit_string_to_int(
+    fn visit_string_to_int<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _input: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_int_to_string(
+    fn traverse_int_to_string<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         input: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(input) && self.visit_int_to_string(expr, input)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, input)?;
+        self.visit_int_to_string(builder, expr, input)
     }
 
-    fn visit_int_to_string(
+    fn visit_int_to_string<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _input: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_stx_get_account(
+    fn traverse_stx_get_account<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         owner: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(owner) && self.visit_stx_get_account(expr, owner)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, owner)?;
+        self.visit_stx_get_account(builder, expr, owner)
     }
 
-    fn visit_stx_get_account(
+    fn visit_stx_get_account<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _owner: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_slice(
+    fn traverse_slice<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         seq: &'a SymbolicExpression,
         left: &'a SymbolicExpression,
         right: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(seq)
-            && self.traverse_expr(left)
-            && self.traverse_expr(right)
-            && self.visit_slice(expr, seq, left, right)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, seq)?;
+        builder = self.traverse_expr(builder, left)?;
+        builder = self.traverse_expr(builder, right)?;
+        self.visit_slice(builder, expr, seq, left, right)
     }
 
-    fn visit_slice(
+    fn visit_slice<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _seq: &'a SymbolicExpression,
         _left: &'a SymbolicExpression,
         _right: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_get_burn_block_info(
+    fn traverse_get_burn_block_info<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         prop_name: &'a ClarityName,
         block: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(block) && self.visit_get_burn_block_info(expr, prop_name, block)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, block)?;
+        self.visit_get_burn_block_info(builder, expr, prop_name, block)
     }
 
-    fn visit_get_burn_block_info(
+    fn visit_get_burn_block_info<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _prop_name: &'a ClarityName,
         _block: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_to_consensus_buff(
+    fn traverse_to_consensus_buff<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         input: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(input) && self.visit_to_consensus_buff(expr, input)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, input)?;
+        self.visit_to_consensus_buff(builder, expr, input)
     }
 
-    fn visit_to_consensus_buff(
+    fn visit_to_consensus_buff<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _input: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_from_consensus_buff(
+    fn traverse_from_consensus_buff<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         type_expr: &'a SymbolicExpression,
         input: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(type_expr)
-            && self.traverse_expr(input)
-            && self.visit_from_consensus_buff(expr, type_expr, input)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, type_expr)?;
+        builder = self.traverse_expr(builder, input)?;
+        self.visit_from_consensus_buff(builder, expr, type_expr, input)
     }
 
-    fn visit_from_consensus_buff(
+    fn visit_from_consensus_buff<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _type_expr: &'a SymbolicExpression,
         _input: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_bitwise(
+    fn traverse_bitwise<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         func: NativeFunctions,
         operands: &'a [SymbolicExpression],
-    ) -> bool {
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
         for operand in operands {
-            if !self.traverse_expr(operand) {
-                return false;
-            }
+            builder = self.traverse_expr(builder, operand)?;
         }
-        self.visit_bitwise(expr, func, operands)
+        self.visit_bitwise(builder, expr, func, operands)
     }
 
-    fn visit_bitwise(
+    fn visit_bitwise<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _func: NativeFunctions,
         _operands: &'a [SymbolicExpression],
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_replace_at(
+    fn traverse_replace_at<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         sequence: &'a SymbolicExpression,
         index: &'a SymbolicExpression,
         element: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(sequence)
-            && self.traverse_expr(index)
-            && self.traverse_expr(element)
-            && self.visit_replace_at(expr, sequence, element, index)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, sequence)?;
+        builder = self.traverse_expr(builder, index)?;
+        builder = self.traverse_expr(builder, element)?;
+        self.visit_replace_at(builder, expr, sequence, element, index)
     }
 
-    fn visit_replace_at(
+    fn visit_replace_at<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _sequence: &'a SymbolicExpression,
         _index: &'a SymbolicExpression,
         _element: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 
-    fn traverse_bit_shift(
+    fn traverse_bit_shift<'b>(
         &mut self,
+        mut builder: InstrSeqBuilder<'b>,
         expr: &'a SymbolicExpression,
         func: NativeFunctions,
         input: &'a SymbolicExpression,
         shamt: &'a SymbolicExpression,
-    ) -> bool {
-        self.traverse_expr(input)
-            && self.traverse_expr(shamt)
-            && self.visit_bit_shift(expr, func, input, shamt)
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        builder = self.traverse_expr(builder, input)?;
+        builder = self.traverse_expr(builder, shamt)?;
+        self.visit_bit_shift(builder, expr, func, input, shamt)
     }
 
-    fn visit_bit_shift(
+    fn visit_bit_shift<'b>(
         &mut self,
+        builder: InstrSeqBuilder<'b>,
         _expr: &'a SymbolicExpression,
         _func: NativeFunctions,
         _input: &'a SymbolicExpression,
         _shamt: &'a SymbolicExpression,
-    ) -> bool {
-        true
+    ) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
+        Ok(builder)
     }
 }
 
-pub fn traverse<'a>(visitor: &mut impl ASTVisitor<'a>, exprs: &'a [SymbolicExpression]) -> bool {
+pub fn traverse<'a, 'b>(
+    visitor: &mut impl ASTVisitor<'a>,
+    mut builder: InstrSeqBuilder<'b>,
+    exprs: &'a [SymbolicExpression],
+) -> Result<InstrSeqBuilder<'b>, InstrSeqBuilder<'b>> {
     for expr in exprs {
-        if !visitor.traverse_expr(expr) {
-            return false;
-        }
+        builder = visitor.traverse_expr(builder, expr)?;
     }
-    true
+    Ok(builder)
 }
 
-fn match_tuple(
+fn match_tuple<'b>(
     expr: &SymbolicExpression,
 ) -> Option<HashMap<Option<&ClarityName>, &SymbolicExpression>> {
     if let Some(list) = expr.match_list() {
@@ -2549,7 +2909,9 @@ fn match_tuple(
     None
 }
 
-fn match_pairs(expr: &SymbolicExpression) -> Option<HashMap<&ClarityName, &SymbolicExpression>> {
+fn match_pairs<'b>(
+    expr: &SymbolicExpression,
+) -> Option<HashMap<&ClarityName, &SymbolicExpression>> {
     let list = expr.match_list()?;
     let mut tuple_map = HashMap::new();
     for pair_list in list {


### PR DESCRIPTION
- Add stack management
    - Variables that require stack allocation can be allocated onto the stack.
    The stack is managed by a new function prelude/postlude.
- Support creating a block in the Wasm
    - This is used initially for containing all of the code in a function, so
    that all exits from the function can easily exit the block and execute
    the function postlude before leaving the function. Doing this required a
    significant refactoring, to allow us to the `InstrSeqBuilder` around and
    avoid problems from the borrow checker.